### PR TITLE
Fixed 'deprecated class keyword for protocol objects'

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,7 @@ A library for both iOS and Android that is based on this library is available fo
 
 ### Xamarin
 
-Simple binding libraries for iOS and Android are available on nuget:
-[xamarin.nordic.dfu.android](https://www.nuget.org/packages/xamarin.nordic.dfu.android/)
+Simple binding library for iOS is available on nuget:
 [xamarin.nordic.dfu.ios](https://www.nuget.org/packages/Xamarin.Nordic.DFU.iOS/)
 
 ---

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ An unofficial library for both iOS and Android that is based on this library is 
 A library for both iOS and Android that is based on this library is available for Flutter: 
 [flutter-nordic-dfu](https://github.com/fengqiangboy/flutter-nordic-dfu) 
 
+### Xamarin
+
+Simple binding libraries for iOS and Android are available on nuget:
+[xamarin.nordic.dfu.android](https://www.nuget.org/packages/xamarin.nordic.dfu.android/)
+[xamarin.nordic.dfu.ios](https://www.nuget.org/packages/Xamarin.Nordic.DFU.iOS/)
+
 ---
 
 ### Resources

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ A library for both iOS and Android that is based on this library is available fo
 ### Xamarin
 
 Simple binding library for iOS is available on nuget:
-[xamarin.nordic.dfu.ios](https://www.nuget.org/packages/Xamarin.Nordic.DFU.iOS/)
+[Laerdal.Xamarin.Dfu.iOS](https://www.nuget.org/packages/Laerdal.Xamarin.Dfu.iOS/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@
 
 - Create/Update your **Podfile** with the following contents
 
-    ```
-    target 'YourAppTargetName' do
-        use_frameworks!
-        pod 'iOSDFULibrary'
-    end
-    ```
+```ruby
+target 'YourAppTargetName' do
+    use_frameworks!
+    pod 'iOSDFULibrary'
+end
+```
 
 - Install dependencies
 
-    ```
-    pod install
-    ```
+```ruby
+pod install
+```
 
 - Open the newly created `.xcworkspace`
 
@@ -31,15 +31,15 @@
 
 - Create a new **Cartfile** in your project's root with the following contents
 
-    ```
-    github "NordicSemiconductor/IOS-Pods-DFU-Library" ~> x.y //Replace x.y with your required version
-    ```
+```ogld
+github "NordicSemiconductor/IOS-Pods-DFU-Library" ~> x.y //Replace x.y with your required version
+```
 
 - Build with carthage
 
-    ```
-    carthage update --platform iOS //also OSX platform is available for macOS builds
-    ```
+```sh
+carthage update --platform iOS //also OSX platform is available for macOS builds
+```
 
 - Carthage will build the **iOSDFULibrary.framework** and **ZipFramework.framework** files in **Carthage/Build/**, 
 you may now copy all those files to your project and use the library, additionally, carthade also builds **\*.dsym** files 

--- a/iOSDFULibrary/Classes/Implementation/DFUPeripheralSelectorDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/DFUPeripheralSelectorDelegate.swift
@@ -66,7 +66,7 @@ import CoreBluetooth
  
  More: http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v14.0.0/service_dfu.html
  */
-@objc public protocol DFUPeripheralSelectorDelegate : class {
+@objc public protocol DFUPeripheralSelectorDelegate: AnyObject {
     
     /**
      Returns whether the given peripheral is a device in DFU Bootloader mode.

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUExecutor.swift
@@ -32,7 +32,7 @@ import CoreBluetooth
 
 typealias DelegateCallback = (DFUServiceDelegate) -> Void
 
-internal protocol BaseExecutorAPI : class, DFUController {
+internal protocol BaseExecutorAPI: AnyObject, DFUController {
     
     /**
      Starts the DFU operation.

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheral.swift
@@ -30,7 +30,7 @@
 
 import CoreBluetooth
 
-internal protocol BaseDFUPeripheralAPI : class, DFUController {
+internal protocol BaseDFUPeripheralAPI: AnyObject, DFUController {
     
     /**
      This method starts DFU process for given peripheral. If the peripheral is

--- a/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheralDelegate.swift
+++ b/iOSDFULibrary/Classes/Implementation/GenericDFU/DFUPeripheralDelegate.swift
@@ -28,7 +28,7 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-internal protocol BasePeripheralDelegate : class {
+internal protocol BasePeripheralDelegate: AnyObject {
     
     /**
      Method called when the iDevice failed to connect to the given peripheral.

--- a/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
+++ b/iOSDFULibrary/Classes/Implementation/SecureDFU/Characteristics/SecureDFUPacket.swift
@@ -58,7 +58,8 @@ internal class SecureDFUPacket: DFUCharacteristic {
         self.logger = logger
         
         if #available(iOS 9.0, macOS 10.12, *) {
-            packetSize = UInt32(characteristic.service.peripheral.maximumWriteValueLength(for: .withoutResponse))
+            // Make the packet size the first word-aligned value that's less than the maximum.
+            packetSize = UInt32(characteristic.service.peripheral.maximumWriteValueLength(for: .withoutResponse)) & 0xFFFFFFFC
             if packetSize > 20 {
                 // MTU is 3 bytes larger than payload
                 // (1 octet for Op-Code and 2 octets for Att Handle).

--- a/iOSDFULibrary/Classes/Utilities/Logging/LoggerDelegate.swift
+++ b/iOSDFULibrary/Classes/Utilities/Logging/LoggerDelegate.swift
@@ -65,7 +65,7 @@ import Foundation
 /**
  *  The Logger delegate.
  */
-@objc public protocol LoggerDelegate : class {
+@objc public protocol LoggerDelegate: AnyObject {
     
     /**
      This method is called whenever a new log entry is to be saved. The logger


### PR DESCRIPTION
In Swift 5.3, the use of 'class' to define protocols that require objects to implement them has been deprecated in favor of 'AnyObject'. This change addresses that specific set of Xcode warnings.